### PR TITLE
feat: Add an Option to Omit Success Icon + New GA Workflow

### DIFF
--- a/.github/workflows/run-linter.yml
+++ b/.github/workflows/run-linter.yml
@@ -1,0 +1,21 @@
+name: "Run Linter"
+
+on: pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Lint with Pint
+        uses: aglipanci/laravel-pint-action@2.2.0
+
+      - name: Commit linted files
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "fix: Files linted with Pint"
+

--- a/.github/workflows/run-pest.yml
+++ b/.github/workflows/run-pest.yml
@@ -1,4 +1,5 @@
 name: "Run Tests"
+
 on:
   push:
     branches:

--- a/resources/views/livewire/rating.blade.php
+++ b/resources/views/livewire/rating.blade.php
@@ -19,7 +19,7 @@
         </div>
     @endfor
 
-    @if($modelRated)
+    @if($modelRated && $showSuccess)
         <div class="ml-6">
             <i class="fas fa-circle-check text-green-500 {{ $size }}"></i>
         </div>

--- a/src/Http/Livewire/Rating.php
+++ b/src/Http/Livewire/Rating.php
@@ -8,13 +8,13 @@ use Livewire\Component;
 
 class Rating extends Component
 {
-    public string $iconBgColor = 'text-yellow-300';
-
-    public string $iconFgColor = 'text-yellow-400';
-
     public $hoverValue = 0;
 
     public string $iconBg = 'far fa-star';
+
+    public string $iconBgColor = 'text-yellow-300';
+
+    public string $iconFgColor = 'text-yellow-400';
 
     public string $iconFg = 'fas fa-star';
 
@@ -23,6 +23,8 @@ class Rating extends Component
     public bool $modelRated;
 
     public float $score = 0;
+
+    public bool $showSuccess = true;
 
     public string $size = 'text-base';
 
@@ -40,8 +42,6 @@ class Rating extends Component
     public function setRating($value): void
     {
         $this->model->rate($value);
-
-        $this->hoverValue = 0;
 
         $this->modelRated = true;
 


### PR DESCRIPTION
This PR adds a new attribute that allows you to omit the success icon used when rating a model. You can add `:show-success="false"` to the Livewire component if you don't want it to show after you have rated a Model.

Also, removed the setting of the `hoverValue` when setting a rating. This gives a better visual indicator as to what you have rated the Model. Before, it would recalculate on click.

I have also added a new Actions workflow to make sure Pint is run on files and committed.