### PR TITLE
Add nullOnDelete() for the User-related foreignId column

### DIFF
--- a/database/migrations/create_ratings_table.php
+++ b/database/migrations/create_ratings_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('ratings', function (Blueprint $table) {
             $table->id();
             $table->morphs('rateable');
-            $table->foreignId((string) config(key: 'rating.users.primary_key', default: 'user_id'))->nullable()->constrained();
+            $table->foreignId((string) config(key: 'rating.users.primary_key', default: 'user_id'))->nullable()->constrained()->nullOnDelete();
             $table->integer('rating');
             $table->timestamps();
         });

--- a/tests/Concerns/CanBeRatedTest.php
+++ b/tests/Concerns/CanBeRatedTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Cjmellor\Rating\Models\Rating;
-use Illuminate\Support\Facades\DB;
-use Cjmellor\Rating\Tests\Models\FakeUser;
-use Cjmellor\Rating\Exceptions\MaxRatingException;
 use Cjmellor\Rating\Exceptions\CannotBeRatedException;
+use Cjmellor\Rating\Exceptions\MaxRatingException;
+use Cjmellor\Rating\Models\Rating;
+use Cjmellor\Rating\Tests\Models\FakeUser;
+use Illuminate\Support\Facades\DB;
 
 test(description: 'a Model can be rated', closure: function () {
     // Create a Rating and attach to a fake User

--- a/tests/Models/FakeUser.php
+++ b/tests/Models/FakeUser.php
@@ -15,4 +15,6 @@ class FakeUser extends User
      * @var bool
      */
     public $timestamps = false;
+
+    protected $table = 'users';
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,15 +15,17 @@ class TestCase extends Orchestra
     {
         config()->set('database.default', 'testing');
 
-        $migration = include __DIR__.'/../database/migrations/create_ratings_table.php';
-
-        $migration->up();
-
-        Schema::create(table: 'fake_users', callback: function (Blueprint $table) {
+        Schema::create(table: 'users', callback: function (Blueprint $table) {
             $table->id();
             $table->string(column: 'username');
             $table->string(column: 'password');
         });
+
+        Schema::enableForeignKeyConstraints();
+
+        $migration = include __DIR__.'/../database/migrations/create_ratings_table.php';
+
+        $migration->up();
     }
 
     protected function setUp(): void


### PR DESCRIPTION
This PR adds nullOnDelete() for the User-related foreignId column in the ratings table, making it possible to preserve ratings when the associated User is deleted.

Additionally, it ensures that the deletion of a User does not result in database errors related to foreign key constraints.